### PR TITLE
Fix iOS 13 crash by removing hacky use of statusBar

### DIFF
--- a/DKPhotoGallery/DKPhotoGallery.swift
+++ b/DKPhotoGallery/DKPhotoGallery.swift
@@ -108,12 +108,6 @@ DKPhotoGalleryContentDataSource, DKPhotoGalleryContentDelegate {
         contentVC.currentIndex = min(self.presentationIndex, self.numberOfItems() - 1)
         
         contentVC.footerView = self.footerView
-        
-        let keyData = Data(bytes: [0x73, 0x74, 0x61, 0x74, 0x75, 0x73, 0x42, 0x61, 0x72])
-        let key = String(data: keyData, encoding: String.Encoding.ascii)!
-        if let statusBar = UIApplication.shared.value(forKey: key) as? UIView {
-            self.statusBar = statusBar
-        }
     }
     
     private lazy var doSetupOnce: () -> Void = {


### PR DESCRIPTION
On iOS 13 if use DKImagePicker and long press an image to try to bring up DKPhotoGallery, it crashes citing the use of the statusBar 