### PR TITLE
Allow modification of SDWebImageDownloader headers

### DIFF
--- a/DKPhotoGallery/Preview/ImagePreview/DKPhotoImageDownloader.swift
+++ b/DKPhotoGallery/Preview/ImagePreview/DKPhotoImageDownloader.swift
@@ -35,6 +35,7 @@ class DKPhotoImageWebDownloader: DKPhotoImageDownloader {
         let config = SDWebImageDownloaderConfig()
         config.executionOrder = .lifoExecutionOrder
         let downloader = SDWebImageDownloader.init(config: config)
+        downloader.requestModifier = SDWebImageDownloader.shared.requestModifier
         
         return downloader
     }()


### PR DESCRIPTION
In my project I need to add custom headers to `SDWebImageDownloader` in order to be able to download the images for the gallery. Currently this is not possible because `DKPhotoGallery` uses custom instance of `SDWebImageDownloader`

Applying requestModifier of the shared instance to custom instance of `SDWebImageDownloader` make it possible to set custom headers.