### PR TITLE
update: add PrivacyInfo.xcprivacy

### DIFF
--- a/DKPhotoGallery/Resource/Resources/PrivacyInfo.xcprivacy
+++ b/DKPhotoGallery/Resource/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSPrivacyTracking</key>
+  <false/>
+  <key>NSPrivacyTrackingDomains</key>
+  <array/>
+  <key>NSPrivacyCollectedDataTypes</key>
+  <array/>
+  <key>NSPrivacyAccessedAPITypes</key>
+  <array/>
+</dict>
+</plist>     


### PR DESCRIPTION
According to the definition of "third-party SDKs" that as mentioned in the WWDC23, new documents: [Privacy manifest files | Apple Developer Documentation](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files) and the [third-party-SDK-requirements](https://developer.apple.com/cn/support/third-party-SDK-requirements/) from Apple. It seems like DKPhotoGallery require a privacy manifest and signature as well.